### PR TITLE
Fix #1 (Can't build hacspec_cryptolib).

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: Build & Test
+
+on: [push, pull_request]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Build
+        run: cargo build --verbose
+      - name: Test
+        run: cargo test --verbose
+      - name: Test Release
+        run: |
+          cargo clean
+          cargo test --release --verbose

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ fstar/*.lax
 
 # CLion
 .idea
+
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ Cargo.lock
 fstar/.depend
 fstar/_tags
 fstar/*.lax
+
+# CLion
+.idea

--- a/hacspec_cryptolib/src/cryptolib.rs
+++ b/hacspec_cryptolib/src/cryptolib.rs
@@ -515,8 +515,8 @@ fn p256_sign(
     let nonce = P256Scalar::from_byte_seq_be(&entropy);
     match ecdsa_p256_sha256_sign(payload, P256Scalar::from_byte_seq_be(ps), nonce) {
         // The ASN.1 encoding happens later on the outside.
-        SignatureResult::Ok((r, s)) => concat_signature(r, s),
-        SignatureResult::Err(_) => CryptoByteSeqResult::Err(CRYPTO_ERROR),
+        P256SignatureResult::Ok((r, s)) => concat_signature(r, s),
+        P256SignatureResult::Err(_) => CryptoByteSeqResult::Err(CRYPTO_ERROR),
     }
 }
 
@@ -544,8 +544,8 @@ fn p256_verify(pk: &VerificationKey, payload: &ByteSeq, sig: &ByteSeq) -> EmptyR
         P256Scalar::from_byte_seq_be(&sig.slice(32, 32)),
     );
     match ecdsa_p256_sha256_verify(payload, (pk_x, pk_y), (r, s)) {
-        VerifyResult::Ok(()) => EmptyResult::Ok(()),
-        VerifyResult::Err(_) => EmptyResult::Err(VERIFY_FAILED),
+        P256VerifyResult::Ok(()) => EmptyResult::Ok(()),
+        P256VerifyResult::Err(_) => EmptyResult::Err(VERIFY_FAILED),
     }
 }
 


### PR DESCRIPTION
This is a fix for #1. The types `VerifyResult` and `SignatureResult` are not imported. I believe it must be `P256VerifyResult` and `P256SignatureResult` instead. With the change in place, the code builds successfully.